### PR TITLE
Edit event to be equal if both name and time is equal

### DIFF
--- a/src/main/java/seedu/address/model/person/Event.java
+++ b/src/main/java/seedu/address/model/person/Event.java
@@ -79,6 +79,7 @@ public class Event {
     public boolean isSameEvent(Event otherEvent) {
         if (otherEvent == this) {
             return true;
+        }
 
         return otherEvent != null
                 && otherEvent.getName().equals(getName())

--- a/src/main/java/seedu/address/model/person/Event.java
+++ b/src/main/java/seedu/address/model/person/Event.java
@@ -73,16 +73,16 @@ public class Event {
     }
 
     /**
-     * Returns true if both events have the same name.
+     * Returns true if both events have the same name and the same timing.
      * This defines a weaker notion of equality between two events.
      */
     public boolean isSameEvent(Event otherEvent) {
         if (otherEvent == this) {
             return true;
-        }
 
         return otherEvent != null
-                && otherEvent.getName().equals(getName());
+                && otherEvent.getName().equals(getName())
+                && otherEvent.getTiming().equals(getTiming());
     }
 
     /**

--- a/src/test/java/seedu/address/model/person/EventTest.java
+++ b/src/test/java/seedu/address/model/person/EventTest.java
@@ -2,7 +2,13 @@ package seedu.address.model.person;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_START_TIME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_END_TIME_AMY;
+
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
@@ -86,5 +92,7 @@ public class EventTest {
         // different time -> return false
         editedAlice = new PersonBuilder(ALICE).withTiming(VALID_START_TIME_AMY, VALID_END_TIME_AMY).build();
         assertFalse(ALICE.equals(editedAlice));
+
+
     }
 }

--- a/src/test/java/seedu/address/model/person/EventTest.java
+++ b/src/test/java/seedu/address/model/person/EventTest.java
@@ -49,6 +49,11 @@ public class EventTest {
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
         assertFalse(BOB.isSameEvent(editedBob));
+
+        // same name, different timing -> returns false
+        editedAlice = new PersonBuilder(ALICE).withTiming(VALID_START_TIME_AMY, VALID_END_TIME_AMY)
+                .build();
+        assertFalse(ALICE.isSameEvent(editedAlice));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/EventTest.java
+++ b/src/test/java/seedu/address/model/person/EventTest.java
@@ -2,10 +2,7 @@ package seedu.address.model.person;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.*;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
@@ -85,5 +82,9 @@ public class EventTest {
 
         // different tags -> returns false
         assertFalse(ALICE.hashCode() == (BOB.hashCode()));
+
+        // different time -> return false
+        editedAlice = new PersonBuilder(ALICE).withTiming(VALID_START_TIME_AMY, VALID_END_TIME_AMY).build();
+        assertFalse(ALICE.equals(editedAlice));
     }
 }

--- a/src/test/java/seedu/address/model/person/EventTest.java
+++ b/src/test/java/seedu/address/model/person/EventTest.java
@@ -3,12 +3,11 @@ package seedu.address.model.person;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_END_TIME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_START_TIME_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_END_TIME_AMY;
-
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;


### PR DESCRIPTION
Added the condition for the event to be equal to be

1. Same event name
2. Same timing for the event

Reason being that the same event can happen multiple times, but each at a different timing. This should account for this condition.